### PR TITLE
Update Help Center JWT API references

### DIFF
--- a/community-roadmap/backend/README.md
+++ b/community-roadmap/backend/README.md
@@ -40,7 +40,7 @@ When the service is running locally, you can run the tests easily, like this:
 npm run test
 ```
 
-If you need to run the tests against a production service, you need a Zendesk instance and an instance of the community-roadmap service deployed. The Zendesk instance must have the Help Center Integration Token endpoint feature enabled (currently in EAP, available on URL `/hc/api/v2/integration/token`). You should also go to Admin Center to create an API token for your user.
+If you need to run the tests against a production service, you need a Zendesk instance and an instance of the community-roadmap service deployed. The Zendesk instance must have the [secure end-user experience integrations for Help Center](https://support.zendesk.com/hc/en-us/articles/5860358664730) feature. You should also go to Admin Center to create an API token for your user.
 
 Example run against production Zendesk and Cloudflare service:
 ```

--- a/community-roadmap/backend/README.md
+++ b/community-roadmap/backend/README.md
@@ -40,7 +40,7 @@ When the service is running locally, you can run the tests easily, like this:
 npm run test
 ```
 
-If you need to run the tests against a production service, you need a Zendesk instance and an instance of the community-roadmap service deployed. The Zendesk instance must have the [secure end-user experience integrations for Help Center](https://support.zendesk.com/hc/en-us/articles/5860358664730) feature. You should also go to Admin Center to create an API token for your user.
+If you need to run the tests against a production service, you need a Zendesk instance and an instance of the community-roadmap service deployed. The Zendesk instance must be on the Guide Enterprise or Suite Enterprise plan. You should also go to Admin Center in Zendesk to create an API token for your user.
 
 Example run against production Zendesk and Cloudflare service:
 ```

--- a/community-roadmap/backend/src/index.js
+++ b/community-roadmap/backend/src/index.js
@@ -43,7 +43,7 @@ async function handleRequest(request, responseHeaders) {
   const decodedToken = jwt.decodeJwt(encodedToken);
   const currentUserId = decodedToken?.payload?.userId;
 
-  if (endpoint == "GET /hc/api/v2/integration/token") {
+  if (endpoint == "GET /api/v2/help_center/integration/token") {
     if (isTestMode) {
       // get token endpoint
       return response(200, responseHeaders, { "token": jwt.getTestToken() })

--- a/community-roadmap/backend/tests/AcceptanceTests.postman_collection.json
+++ b/community-roadmap/backend/tests/AcceptanceTests.postman_collection.json
@@ -47,7 +47,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{baseUrl}}/hc/api/v2/integration/token",
+					"raw": "{{baseUrl}}/api/v2/help_center/integration/token",
 					"host": [
 						"{{baseUrl}}"
 					],

--- a/community-roadmap/frontend/public/index.html
+++ b/community-roadmap/frontend/public/index.html
@@ -10,7 +10,7 @@
     <div style="width: 90%; margin-left: auto; margin-right: auto;">
       <p>Test page with a product roadmap...</p>
       <p>&nbsp;</p>
-      <div data-product-key="testproduct" class="roadmapContainer" data-backend-base-url="http://127.0.0.1:8787" data-token-endpoint-url="http://127.0.0.1:8787/hc/api/v2/integration/token"></div>
+      <div data-product-key="testproduct" class="roadmapContainer" data-backend-base-url="http://127.0.0.1:8787" data-token-endpoint-url="http://127.0.0.1:8787/api/v2/help_center/integration/token"></div>
     </div>
 
     <script type="text/javascript">

--- a/community-roadmap/frontend/src/index.js
+++ b/community-roadmap/frontend/src/index.js
@@ -15,7 +15,7 @@ for (let i = 0; i < roadmapElements.length; i++) {
     console.log("No data-backend-base-url value provided for roadmap '" + productKey + "'. Skipping.")
     continue;
   }
-  const tokenEndpointUrl = roadmapElement.dataset.tokenEndpointUrl || "/hc/api/v2/integration/token";
+  const tokenEndpointUrl = roadmapElement.dataset.tokenEndpointUrl || "/api/v2/help_center/integration/token";
   console.log("Rendering product '" + productKey + "' from backend " + backendBaseUrl);
   const root = ReactDOM.createRoot(roadmapElement);
   root.render(


### PR DESCRIPTION
We've now launched the [Secure end-user experience integrations for Help center](https://support.zendesk.com/hc/en-us/articles/5860358664730-Announcing-Secure-end-user-experience-integrations-for-Help-center) 🥳 

As part of the launch, we've updated the paths of the JWT endpoints to be consistent with other Help Center endpoints.

So

```
/hc/api/v2/integration/token
```

has been replaced by

```
/api/v2/help_center/integration/token
```

This PR updates the references in this repository to match [our API docs](https://developer.zendesk.com/api-reference/help_center/help-center-api/help_center_jwts/#new-token).